### PR TITLE
feat: add GetMetatransactionNonce base contract

### DIFF
--- a/dist/core/GetMetatransactionNonce.json
+++ b/dist/core/GetMetatransactionNonce.json
@@ -1,0 +1,24 @@
+{
+    "contractName": "GetMetatransactionNonce",
+    "abi": [
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_user",
+                    "type": "address"
+                }
+            ],
+            "name": "getMetatransactionNonce",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_nonce",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a `GetMetatransactionNonce` base contract abi to have a base class with the latest changes (might be superfluous once contracts are consistently named)